### PR TITLE
Support for Laravel v6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - nightly
@@ -10,6 +8,7 @@ php:
 cache:
     directories:
         - "$HOME/.composer/cache"
+
 env:
   matrix:
     - COMPOSER_FLAGS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,13 @@ cache:
     directories:
         - "$HOME/.composer/cache"
 
-env:
-  matrix:
-    - COMPOSER_FLAGS=""
+matrix:
+    allow_failures:
+        - php: nightly
 
 before_install:
   - sudo apt-get update
   - travis_retry composer self-update
-#  - mv phpunit.xml.dist phpunit.xml
 
 install:
   - travis_retry composer update --prefer-source $PREFER_LOWEST

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "php": "~5.6|~7.0",
         "ext-intl": "*",
         "dompdf/dompdf": "^0.8.0",
-        "illuminate/support": "~5.1|~5.2|~5.3|~5.4|~5.5|~5.6",
-        "nesbot/carbon": "^1.22"
+        "illuminate/support": "^5.8 || ^6.0",
+        "nesbot/carbon": "^1.22 || ^2.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,16 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "^7.2",
         "ext-intl": "*",
         "dompdf/dompdf": "^0.8.0",
-        "illuminate/support": "^5.8 || ^6.0",
-        "nesbot/carbon": "^1.22 || ^2.0"
+        "illuminate/support": "^5.8|^6.0",
+        "nesbot/carbon": "^1.22|^2.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^3.3",
-        "mockery/mockery": "^0.9.9",
-        "orchestra/database": "^3.4",
-        "phpunit/phpunit" : "~4.0||~5.0||~6.0||~7.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "graham-campbell/testbench": "^5.2",
+        "phpunit/phpunit": "^7.5|^8.3",
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -32,7 +32,7 @@ class AbstractTestCase extends AbstractPackageTestCase
         return InvoicableServiceProvider::class;
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->withPackageMigrations();

--- a/tests/Feature/InvoiceTest.php
+++ b/tests/Feature/InvoiceTest.php
@@ -11,7 +11,7 @@ class InvoiceTest extends AbstractTestCase
 {
     use DatabaseMigrations;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->testModel = new TestModel();

--- a/tests/Unit/InvoiceReferenceTest.php
+++ b/tests/Unit/InvoiceReferenceTest.php
@@ -13,7 +13,7 @@ class InvoiceReferenceTest extends AbstractTestCase
 {
     use DatabaseMigrations;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->reference = InvoiceReferenceGenerator::generate();
@@ -56,7 +56,7 @@ class InvoiceReferenceTest extends AbstractTestCase
         $references = array_map(function () {
             return InvoiceReferenceGenerator::generate();
         }, range(1, 100));
-        
+
         $this->assertCount(100, array_unique($references));
     }
 }

--- a/tests/Unit/MoneyFormatterTest.php
+++ b/tests/Unit/MoneyFormatterTest.php
@@ -7,7 +7,7 @@ use SanderVanHooft\Invoicable\MoneyFormatter;
 
 class MoneyFormatterTest extends AbstractTestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->formatter = new MoneyFormatter();


### PR DESCRIPTION
- Dropped support for Laravel versions prior to v5.8.
- Added support for Laravel v6.
- Added support for Carbon v2.